### PR TITLE
Do not self combine

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ You can also require a set of multiple labels
 gh combine owner/repo --labels security,dependencies
 ```
 
+> Note that the labels are OR'd together. So if a pull request has either label, it will be included in the combined pull request. Meaning that if you use `--labels security,dependencies` and a pull request has the `security` label, it will be included in the combined pull request even if it does not have the `dependencies` label.
+
 ### Only Combine Pull Requests that match a given Regex
 
 ```bash
@@ -132,6 +134,8 @@ gh combine owner/repo --branch-suffix "-some-cool-feature"
 ```bash
 gh combine owner/repo --ignore-labels wip,dependencies
 ```
+
+> Note that labels are OR'd together. So if a pull request has either label, it will be ignored in the combined pull request. Meaning that if you use `--ignore-labels wip,dependencies` and a pull request has the `wip` label, it will be ignored in the combined pull request even if it does not have the `dependencies` label.
 
 ### Update the Resulting Combined Pull Request Branch if Possible
 

--- a/internal/cmd/match_criteria.go
+++ b/internal/cmd/match_criteria.go
@@ -28,6 +28,11 @@ func PrMatchesCriteria(branch string, prLabels []string) bool {
 
 // checks if a branch matches the branch filtering criteria
 func branchMatchesCriteria(branch string) bool {
+	// Do not attempt to match on existing branches that were created by this CLI
+	if branch == combineBranchName {
+		return false
+	}
+
 	// If no branch filters are specified, all branches pass this check
 	if branchPrefix == "" && branchSuffix == "" && branchRegex == "" {
 		return true

--- a/internal/cmd/match_criteria_test.go
+++ b/internal/cmd/match_criteria_test.go
@@ -111,3 +111,120 @@ func TestLabelsMatch(t *testing.T) {
 		})
 	}
 }
+func TestBranchMatchesCriteria(t *testing.T) {
+	t.Parallel()
+
+	// Define test cases
+	tests := []struct {
+		name          string
+		branch        string
+		combineBranch string
+		prefix        string
+		suffix        string
+		regex         string
+		want          bool
+	}{
+		{
+			name:          "Branch matches all criteria",
+			branch:        "feature/test",
+			combineBranch: "combined-prs",
+			prefix:        "feature/",
+			suffix:        "/test",
+			regex:         `^feature/.*$`,
+			want:          true,
+		},
+		{
+			name:          "Branch is the combine branch",
+			branch:        "combined-prs",
+			combineBranch: "combined-prs",
+			want:          false,
+		},
+		{
+			name:          "Branch ends with the combine branch",
+			branch:        "fix-combined-prs",
+			combineBranch: "combined-prs",
+			want:          true,
+		},
+		{
+			name:          "No filters specified",
+			branch:        "any-branch",
+			combineBranch: "combined-prs",
+			want:          true,
+		},
+		{
+			name:          "No filters specified and partial match on combine branch name",
+			branch:        "bug/combined-prs-fix",
+			combineBranch: "combined-prs",
+			want:          true,
+		},
+		{
+			name:          "Prefix does not match",
+			branch:        "test/feature",
+			combineBranch: "combined-prs",
+			prefix:        "feature/",
+			want:          false,
+		},
+		{
+			name:          "Suffix does not match",
+			branch:        "feature/test",
+			combineBranch: "combined-prs",
+			suffix:        "/feature",
+			want:          false,
+		},
+		{
+			name:          "Regex does not match",
+			branch:        "test/feature",
+			combineBranch: "combined-prs",
+			regex:         `^feature/.*`,
+			want:          false,
+		},
+		{
+			name:          "Invalid regex pattern",
+			branch:        "feature/test",
+			combineBranch: "combined-prs",
+			regex:         `^(feature/.*$`,
+			want:          false,
+		},
+		{
+			name:          "Branch matches prefix only",
+			branch:        "feature/test",
+			combineBranch: "combined-prs",
+			prefix:        "feature/",
+			want:          true,
+		},
+		{
+			name:          "Branch matches suffix only",
+			branch:        "test/feature",
+			combineBranch: "combined-prs",
+			suffix:        "/feature",
+			want:          true,
+		},
+		{
+			name:          "Branch matches regex only",
+			branch:        "feature/test",
+			combineBranch: "combined-prs",
+			regex:         `^feature/.*$`,
+			want:          true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Set global variables for the test
+			combineBranchName = test.combineBranch
+			branchPrefix = test.prefix
+			branchSuffix = test.suffix
+			branchRegex = test.regex
+
+			// Run the function
+			got := branchMatchesCriteria(test.branch)
+
+			// Check the result
+			if got != test.want {
+				t.Errorf("branchMatchesCriteria(%q) = %v; want %v", test.branch, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request makes it so that existing `combine-prs` branches do not get "self combined" into new PRs if they already exist.