### PR TITLE
Stats output

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ gh combine owner/repo --ignore-labels wip,dependencies
 gh combine owner/repo --update-branch
 ```
 
+### Disable Stats Output
+
+```bash
+gh combine owner/repo --no-stats
+```
+
+### Disable Color
+
+```bash
+gh combine owner/repo --no-color
+```
+
 ### Running with Debug Logging
 
 ```bash

--- a/internal/cmd/combine_prs.go
+++ b/internal/cmd/combine_prs.go
@@ -145,12 +145,6 @@ func createPullRequestWithNumber(ctx context.Context, client RESTClientInterface
 	return prResponse.Number, nil
 }
 
-// Keep CombinePRs for backward compatibility
-func CombinePRs(ctx context.Context, graphQlClient *api.GraphQLClient, restClient RESTClientInterface, repo github.Repo, pulls github.Pulls) error {
-	_, _, _, err := CombinePRsWithStats(ctx, graphQlClient, restClient, repo, pulls)
-	return err
-}
-
 // isMergeConflictError checks if the error is a 409 Merge Conflict
 func isMergeConflictError(err error) bool {
 	// Check if the error message contains "HTTP 409: Merge conflict"

--- a/internal/cmd/combine_prs.go
+++ b/internal/cmd/combine_prs.go
@@ -33,14 +33,14 @@ func CombinePRsWithStats(ctx context.Context, graphQlClient *api.GraphQLClient, 
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("failed to get SHA of main branch: %w", err)
 	}
-// Delete any pre-existing working branch
+	// Delete any pre-existing working branch
 
-// Delete any pre-existing working branch
+	// Delete any pre-existing working branch
 	err = deleteBranch(ctx, restClient, repo, workingBranchName)
 	if err != nil {
 		Logger.Debug("Working branch not found, continuing", "branch", workingBranchName)
 
-	// Delete any pre-existing combined branch
+		// Delete any pre-existing combined branch
 	}
 
 	// Delete any pre-existing combined branch

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -35,6 +35,8 @@ var (
 	workingBranchSuffix string
 	dependabot          bool
 	caseSensitiveLabels bool
+	noColor             bool
+	noStats             bool
 )
 
 // NewRootCmd creates the root command for the gh-combine CLI
@@ -96,6 +98,8 @@ func NewRootCmd() *cobra.Command {
       # Additional options
       gh combine owner/repo --autoclose                         # Close source PRs when combined PR is merged
 	  gh combine owner/repo --base-branch main                  # Use a different base branch for the combined PR
+	  gh combine owner/repo --no-color                          # Disable color output
+	  gh combine owner/repo --no-stats                          # Disable stats summary display
 	  gh combine owner/repo --combine-branch-name combined-prs  # Use a different name for the combined PR branch
 	  gh combine owner/repo --working-branch-suffix -working    # Use a different suffix for the working branch
       gh combine owner/repo --update-branch                     # Update the branch of the combined PR`,
@@ -127,6 +131,8 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.Flags().IntVar(&minimum, "minimum", 2, "Minimum number of PRs to combine")
 	rootCmd.Flags().StringVar(&defaultOwner, "owner", "", "Default owner for repositories (if not specified in repo name or missing from file inputs)")
 	rootCmd.Flags().BoolVar(&caseSensitiveLabels, "case-sensitive-labels", false, "Use case-sensitive label matching")
+	rootCmd.Flags().BoolVar(&noColor, "no-color", false, "Disable color output")
+	rootCmd.Flags().BoolVar(&noStats, "no-stats", false, "Disable stats summary display")
 
 	// Add deprecated flags for backward compatibility
 	// rootCmd.Flags().IntVar(&minimum, "min-combine", 2, "Minimum number of PRs to combine (deprecated, use --minimum)")
@@ -175,6 +181,10 @@ func runCombine(cmd *cobra.Command, args []string) error {
 	// Execute combination logic
 	if err := executeCombineCommand(ctx, spinner, repos); err != nil {
 		return fmt.Errorf("command execution failed: %w", err)
+	}
+
+	if !noStats {
+		displayStatsSummary()
 	}
 
 	return nil
@@ -342,4 +352,28 @@ func fetchOpenPullRequests(ctx context.Context, client *api.RESTClient, repo git
 	}
 
 	return allPulls, nil
+}
+
+func displayStatsSummary() {
+	// Example implementation of stats summary display
+	if noColor {
+		fmt.Println("Stats Summary (Color Disabled):")
+	} else {
+		fmt.Println("\033[1;34mStats Summary:\033[0m") // Blue color for title
+	}
+
+	// Example stats data
+	fmt.Println("Repositories Processed: 5")
+	fmt.Println("PRs Combined: 10")
+	fmt.Println("PRs Skipped (Merge Conflicts): 2")
+	fmt.Println("PRs Skipped (Criteria Not Met): 3")
+	fmt.Println("Execution Time: 1m30s")
+
+	if !noColor {
+		fmt.Println("\033[1;32mLinks to Combined PRs:\033[0m") // Green color for links section
+	} else {
+		fmt.Println("Links to Combined PRs:")
+	}
+	fmt.Println("- https://github.com/owner/repo1/pull/123")
+	fmt.Println("- https://github.com/owner/repo2/pull/456")
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -401,13 +401,6 @@ func fetchOpenPullRequests(ctx context.Context, client *api.RESTClient, repo git
 	return allPulls, nil
 }
 
-// CombinePRsWithStats wraps CombinePRs to collect stats and return combined/skipped PRs and the combined PR link
-func CombinePRsWithStats(ctx context.Context, graphQlClient *api.GraphQLClient, restClient RESTClientInterface, repo github.Repo, pulls github.Pulls) (combined []string, mergeConflicts []string, combinedPRLink string, err error) {
-	// ...existing code for CombinePRs...
-	// This is a stub. You should move the logic from CombinePRs here and update it to collect combined, mergeConflicts, and the PR link.
-	return nil, nil, "", CombinePRs(ctx, graphQlClient, restClient, repo, pulls)
-}
-
 func displayStatsSummary(stats *StatsCollector) {
 	elapsed := stats.EndTime.Sub(stats.StartTime)
 	if noColor {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -43,14 +43,14 @@ var (
 
 // StatsCollector tracks stats for the CLI run
 type StatsCollector struct {
-	ReposProcessed int
-	PRsCombined   int
+	ReposProcessed          int
+	PRsCombined             int
 	PRsSkippedMergeConflict int
-	PRsSkippedCriteria int
-	PerRepoStats  map[string]*RepoStats
-	CombinedPRLinks []string
-	StartTime     time.Time
-	EndTime       time.Time
+	PRsSkippedCriteria      int
+	PerRepoStats            map[string]*RepoStats
+	CombinedPRLinks         []string
+	StartTime               time.Time
+	EndTime                 time.Time
 }
 
 type RepoStats struct {
@@ -203,7 +203,7 @@ func runCombine(cmd *cobra.Command, args []string) error {
 
 	stats := &StatsCollector{
 		PerRepoStats: make(map[string]*RepoStats),
-		StartTime: time.Now(),
+		StartTime:    time.Now(),
 	}
 
 	// Execute combination logic

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/cli/go-gh/v2/pkg/api"


### PR DESCRIPTION
This pull request implements a very basic "stats" output for this CLI.

```console
$ gh combine owner/repo

Stats Summary:
Repositories Processed: 1
PRs Combined: 2
PRs Skipped (Merge Conflicts): 0
PRs Skipped (Criteria Not Met): 1
Execution Time: 6s
Links to Combined PRs:
- https://github.com/owner/repo/pull/123

Per-Repository Details:
  owner/repo
    Combined: 2
    Skipped (Merge Conflicts): 0
    Skipped (Criteria): 1
    Combined PR: https://github.com/owner/repo/pull/123
```

It is very basic and will be improved upon in subsequent PRs

---

Resolves: https://github.com/github/gh-combine/issues/14