### PR TITLE
feat: add `--dry-run` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Combine all open pull requests in a repository that are created by dependabot:
 gh combine owner/repo --dependabot
 ```
 
+### In Dry Run Mode
+
+You can run in dry run mode to see what would happen without actually creating a pull request or combining any pull requests:
+
+```bash
+gh combine owner/repo --dry-run
+```
+
 ### With Passing CI
 
 Combine multiple pull requests together but only if their CI checks are passing:

--- a/internal/cmd/output.go
+++ b/internal/cmd/output.go
@@ -236,14 +236,20 @@ func displaySummaryTable(stats *StatsCollector) {
 		21, // Fixed width for the skipped column
 	)
 
+	summaryRowPRCount := interface{}(len(stats.CombinedPRLinks))
+
+	if summaryRowPRCount == 0 && dryRun {
+		summaryRowPRCount = "DRY RUN"
+	}
+
 	// Generate the summary row
 	summaryRow := fmt.Sprintf(
-		"│ %-13d │ %-13d │ %s%s │ %-13d │",
+		"│ %-13d │ %-13d │ %s%s │ %-13v │",
 		stats.ReposProcessed,
 		stats.PRsCombined,
 		skippedSummaryText,
 		summaryPadding,
-		len(stats.CombinedPRLinks),
+		summaryRowPRCount,
 	)
 
 	// Print the summary table

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -115,6 +115,7 @@ func NewRootCmd() *cobra.Command {
       gh combine owner/repo --add-assignees octocat,hubot        # Assign users to the new PR
     
       # Additional options
+	  gh combine owner/repo --dry-run                           # Simulate the actions without making any changes
       gh combine owner/repo --autoclose                         # Close source PRs when combined PR is merged
 	  gh combine owner/repo --base-branch main                  # Use a different base branch for the combined PR
 	  gh combine owner/repo --no-color                          # Disable color output

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -339,9 +339,16 @@ func processRepository(ctx context.Context, client *api.RESTClient, graphQlClien
 		RESTClientInterface
 	}{client}
 
-	// Combine the PRs and collect stats
 	commandString := buildCommandString([]string{repo.String()})
-	combined, mergeConflicts, combinedPRLink, err := CombinePRsWithStats(ctx, graphQlClient, restClientWrapper, repo, matchedPRs, commandString, dryRun)
+
+	opts := CombineOpts{
+		Noop:    dryRun,
+		Command: commandString,
+		Repo:    repo,
+		Pulls:   matchedPRs,
+	}
+
+	combined, mergeConflicts, combinedPRLink, err := CombinePRsWithStats(ctx, graphQlClient, restClientWrapper, opts)
 	if err != nil {
 		return fmt.Errorf("failed to combine PRs: %w", err)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -39,6 +39,7 @@ var (
 	noColor             bool
 	noStats             bool
 	outputFormat        string
+	dryRun              bool
 )
 
 // StatsCollector tracks stats for the CLI run
@@ -154,6 +155,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.Flags().BoolVar(&noColor, "no-color", false, "Disable color output")
 	rootCmd.Flags().BoolVar(&noStats, "no-stats", false, "Disable stats summary display")
 	rootCmd.Flags().StringVar(&outputFormat, "output", "table", "Output format: table, plain, or json")
+	rootCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Simulate the actions without making any changes")
 
 	// Add deprecated flags for backward compatibility
 	// rootCmd.Flags().IntVar(&minimum, "min-combine", 2, "Minimum number of PRs to combine (deprecated, use --minimum)")
@@ -338,7 +340,7 @@ func processRepository(ctx context.Context, client *api.RESTClient, graphQlClien
 
 	// Combine the PRs and collect stats
 	commandString := buildCommandString([]string{repo.String()})
-	combined, mergeConflicts, combinedPRLink, err := CombinePRsWithStats(ctx, graphQlClient, restClientWrapper, repo, matchedPRs, commandString)
+	combined, mergeConflicts, combinedPRLink, err := CombinePRsWithStats(ctx, graphQlClient, restClientWrapper, repo, matchedPRs, commandString, dryRun)
 	if err != nil {
 		return fmt.Errorf("failed to combine PRs: %w", err)
 	}
@@ -476,6 +478,9 @@ func buildCommandString(args []string) string {
 	}
 	if outputFormat != "table" && outputFormat != "" {
 		cmd = append(cmd, "--output", outputFormat)
+	}
+	if dryRun {
+		cmd = append(cmd, "--dry-run")
 	}
 
 	return strings.Join(cmd, " ")


### PR DESCRIPTION
resolves: https://github.com/github/gh-combine/issues/28

### Gotchas

- The logic determining if a branch can be successfully merged or not will not run in `--dry-run` mode (MC stats)