### PR TITLE
fix flakey tests

### DIFF
--- a/internal/cmd/match_criteria.go
+++ b/internal/cmd/match_criteria.go
@@ -15,7 +15,7 @@ import (
 // checks if a PR matches all filtering criteria
 func PrMatchesCriteria(branch string, prLabels []string) bool {
 	// Check branch criteria if any are specified
-	if !branchMatchesCriteria(branch) {
+	if !branchMatchesCriteria(branch, combineBranchName, branchPrefix, branchSuffix, branchRegex) {
 		return false
 	}
 
@@ -28,7 +28,7 @@ func PrMatchesCriteria(branch string, prLabels []string) bool {
 }
 
 // checks if a branch matches the branch filtering criteria
-func branchMatchesCriteria(branch string) bool {
+func branchMatchesCriteria(branch, combineBranchName, branchPrefix, branchSuffix, branchRegex string) bool {
 	Logger.Debug("Checking branch criteria", "branch", branch)
 	// Do not attempt to match on existing branches that were created by this CLI
 	if branch == combineBranchName {

--- a/internal/cmd/match_criteria_test.go
+++ b/internal/cmd/match_criteria_test.go
@@ -267,7 +267,7 @@ func TestBranchMatchesCriteria(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel() // Parallelize at the subtest level, each with their own local variables
 
-			 // Run the function
+			// Run the function
 			got := branchMatchesCriteria(test.branch, test.combineBranch, test.prefix, test.suffix, test.regex)
 
 			// Check the result

--- a/internal/cmd/match_criteria_test.go
+++ b/internal/cmd/match_criteria_test.go
@@ -168,8 +168,6 @@ func TestLabelsMatch(t *testing.T) {
 	}
 }
 func TestBranchMatchesCriteria(t *testing.T) {
-	// Remove t.Parallel() at the function level to avoid races on global variables
-
 	// Define test cases
 	tests := []struct {
 		name          string
@@ -269,28 +267,8 @@ func TestBranchMatchesCriteria(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel() // Parallelize at the subtest level, each with their own local variables
 
-			// Save original values of global variables
-			origCombineBranchName := combineBranchName
-			origBranchPrefix := branchPrefix
-			origBranchSuffix := branchSuffix
-			origBranchRegex := branchRegex
-
-			// Restore original values after test
-			defer func() {
-				combineBranchName = origCombineBranchName
-				branchPrefix = origBranchPrefix
-				branchSuffix = origBranchSuffix
-				branchRegex = origBranchRegex
-			}()
-
-			// Set global variables for this specific test
-			combineBranchName = test.combineBranch
-			branchPrefix = test.prefix
-			branchSuffix = test.suffix
-			branchRegex = test.regex
-
-			// Run the function
-			got := branchMatchesCriteria(test.branch)
+			 // Run the function
+			got := branchMatchesCriteria(test.branch, test.combineBranch, test.prefix, test.suffix, test.regex)
 
 			// Check the result
 			if got != test.want {

--- a/internal/cmd/repos_test.go
+++ b/internal/cmd/repos_test.go
@@ -71,7 +71,6 @@ func TestParseRepositoriesArgs(t *testing.T) {
 }
 
 func TestParseRepositoriesFile(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		content string
 		want    []github.Repo

--- a/script/test
+++ b/script/test
@@ -2,9 +2,11 @@
 
 set -e
 
+count=10
+
 # if the tparse binary is not found, don't use it
 if ! command -v tparse &> /dev/null; then
-  go test -v -cover -coverprofile=coverage.out ./...
+  go test -race -count $count -v -cover -coverprofile=coverage.out ./...
 else
-  set -o pipefail && go test -cover -coverprofile=coverage.out -json ./... | tparse -smallscreen -all -trimpath github.com/github/
+  set -o pipefail && go test -race -count $count -cover -coverprofile=coverage.out -json ./... | tparse -smallscreen -all -trimpath github.com/github/
 fi


### PR DESCRIPTION
The `TestBranchMatchesCriteria` function uses global variables (`combineBranchName`, `branchPrefix`, `branchSuffix`, `branchRegex`) that are modified during each test case. This can lead to race conditions and flakiness when tests are run in parallel. The fix is to refactor the `branchMatchesCriteria` function to accept these variables as parameters instead of relying on global state.

---

resolves: https://github.com/github/gh-combine/issues/34